### PR TITLE
importKeilProject: Fix command assembly

### DIFF
--- a/ideScripts/importKeilProject.py
+++ b/ideScripts/importKeilProject.py
@@ -285,17 +285,16 @@ def createMakefileTemplate(paths: Paths, keilProjData: KeilProjectData):
     _createCubeMxTmpScript(paths, keilProjData)
 
     # run CubeMX as subprocess with this script as a parameter
-    cmdStr = "java -jar \"" + paths.cubeMxExe + "\" "
-    cmdStr += "-s \"" + paths.tmpCubeMxScript + "\" "  # scrip path
+    cmd = ['java', '-jar', paths.cubeMxExe, '-s', paths.tmpCubeMxScript] # scrip path
     if _checkCubeMxFirmwarePackage(paths, keilProjData):
-        cmdStr += "-q"  # no-gui mode
+        cmd.append('-q')  # no-gui mode
         print("\tSTM32CubeMX GUI set to non-visible mode.")
     else:
         print("\tSTM32CubeMX GUI set to visible because of repository warning.")
 
     try:
         print("Generating template Makefile with STM32CubeMX...")
-        proc = subprocess.run(cmdStr, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        proc = subprocess.run(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         if proc.returncode == 0:
             print("\tSTM32CubeMX project generated.")
         else:


### PR DESCRIPTION
It is better to pass args for subprocess.run() as an array.


As the string argument needs to be interpreted and apparently works only on win. I was getting following error on linux:

```
**** ERROR (unrecoverable) ****
Exception error while creating template Makefile with STM32CubeMX:
[Errno 2] No such file or directory: 'java -jar "/home/palco/opt/STM32CubeMX/STM32CubeMX" -s "/home/palco/work/isdd/parking-RN2483-BC68/_tmpCubeMx/tmpCubeMx.txt" ': 'java -jar "/home/palco/opt/STM32CubeMX/STM32CubeMX" -s "/home/palco/work/isdd/parking-RN2483-BC68/_tmpCubeMx/tmpCubeMx.txt" '

Traceback:
Traceback (most recent call last):
  File "ideScripts/importKeilProject.py", line 298, in createMakefileTemplate
    proc = subprocess.run(cmdStr, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
  File "/usr/lib/python3.7/subprocess.py", line 472, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session) 
  File "/usr/lib/python3.7/subprocess.py", line 1522, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'java -jar "/home/palco/opt/STM32CubeMX/STM32CubeMX" -s "/home/palco/work/isdd/parking-RN2483-BC68/_tmpCubeMx/tmpCubeMx.txt" ': 'java -jar "/home/palco/opt/STM32CubeMX/STM32CubeMX" -s "/home/palco/work/isdd/parking-RN2483-BC68/_tmpCubeMx/tmpCubeMx.txt" '
```