### PR TITLE
Fix for .svd invalid path error

### DIFF
--- a/ideScripts/updatePaths.py
+++ b/ideScripts/updatePaths.py
@@ -131,8 +131,6 @@ class UpdatePaths():
 
                 else:  # not a list, a single path expected
                     if not utils.pathExists(buildData[pathName]):
-                        mustBeUpdated = True
-                    else:
                         # path not valid, check if command
                         if not utils.commandExists(buildData[pathName]):
                             mustBeUpdated = True


### PR DESCRIPTION
It checked for a command on a valid path for an .svd file, changed it to check for command on invalid path

fixes #24 